### PR TITLE
chore: add docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:12.16.1
+WORKDIR /var/app/
+
+ADD package-lock.json /var/app/
+ADD package.json /var/app/
+
+RUN npm ci
+
+ADD . /var/app/
+
+RUN npm run build
+
+EXPOSE 4000
+EXPOSE 4000/ws
+CMD ["npm", "start"]


### PR DESCRIPTION
Things still to do:

- [ ] multi-stage build (use alpine to serve)
- [ ] consume the `PORT` environment variable
- [ ] consume `NODE_ENV` variable make HTTPS optional

`NODE_ENV` might be hard for the client side because it's injected by webpack at build time, and can't be changed later